### PR TITLE
Build as "conhost.exe" instead of "OpenConsole.exe"

### DIFF
--- a/src/host/exe/Host.EXE.vcxproj
+++ b/src/host/exe/Host.EXE.vcxproj
@@ -5,7 +5,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>HostEXE</RootNamespace>
     <ProjectName>Host.EXE</ProjectName>
-    <TargetName>OpenConsole</TargetName>
+    <TargetName>conhost</TargetName>
     <ConfigurationType>Application</ConfigurationType>
     <PgoTarget>true</PgoTarget>
   </PropertyGroup>


### PR DESCRIPTION
I made this change as part of my Winoldap fork, but it's useful for the upstream project too.